### PR TITLE
add cli flag to attempt to cast to integer before boolean

### DIFF
--- a/cmd/goxmlstruct/main.go
+++ b/cmd/goxmlstruct/main.go
@@ -23,6 +23,7 @@ var (
 	topLevelAttributes           = flag.Bool("top-level-attributes", xmlstruct.DefaultTopLevelAttributes, "include top level attributes")
 	usePointersForOptionalFields = flag.Bool("use-pointers-for-optional-fields", xmlstruct.DefaultUsePointersForOptionalFields, "use pointers for optional fields")
 	useRawToken                  = flag.Bool("use-raw-token", xmlstruct.DefaultUseRawToken, "use encoding/xml.Decoder.RawToken")
+	observeIntEager              = flag.Bool("observe-int-eager", xmlstruct.DefaultObserveIntEager, "attempt to cast fields as int before bool")
 )
 
 func run() error {
@@ -46,6 +47,7 @@ func run() error {
 		xmlstruct.WithTopLevelAttributes(*topLevelAttributes),
 		xmlstruct.WithUsePointersForOptionalFields(*usePointersForOptionalFields),
 		xmlstruct.WithUseRawToken(*useRawToken),
+		xmlstruct.WithOberveIntEager(*observeIntEager),
 	)
 
 	if flag.NArg() == 0 {

--- a/generator.go
+++ b/generator.go
@@ -42,6 +42,7 @@ type Generator struct {
 	usePointersForOptionalFields bool
 	useRawToken                  bool
 	typeElements                 map[xml.Name]*element
+	oberveIntEager               bool
 }
 
 // A GeneratorOption sets an option on a Generator.
@@ -148,6 +149,15 @@ func WithUseRawToken(useRawToken bool) GeneratorOption {
 	}
 }
 
+// WithOberveIntEager sets whether to observe ints before booleans.
+// this can be useful in the case where an array-like collection of elements
+// are indexed by a field does not exceed 1, and thus is assumed to be boolean
+func WithOberveIntEager(observeIntEager bool) GeneratorOption {
+	return func(g *Generator) {
+		g.oberveIntEager = observeIntEager
+	}
+}
+
 // NewGenerator returns a new Generator with the given options.
 func NewGenerator(options ...GeneratorOption) *Generator {
 	g := &Generator{
@@ -165,6 +175,7 @@ func NewGenerator(options ...GeneratorOption) *Generator {
 		usePointersForOptionalFields: DefaultUsePointersForOptionalFields,
 		useRawToken:                  DefaultUseRawToken,
 		typeElements:                 make(map[xml.Name]*element),
+		oberveIntEager:               DefaultObserveIntEager,
 	}
 	g.exportNameFunc = func(name xml.Name) string {
 		if exportRename, ok := g.exportRenames[name.Local]; ok {
@@ -314,6 +325,7 @@ func (g *Generator) ObserveReader(r io.Reader) error {
 		topLevelAttributes: g.topLevelAttributes,
 		typeOrder:          g.typeOrder,
 		useRawToken:        g.useRawToken,
+		observeIntEager:    g.oberveIntEager,
 	}
 	if g.namedTypes {
 		options.topLevelElements = g.typeElements

--- a/generator.go
+++ b/generator.go
@@ -150,8 +150,8 @@ func WithUseRawToken(useRawToken bool) GeneratorOption {
 }
 
 // WithOberveIntEager sets whether to observe ints before booleans.
-// this can be useful in the case where an array-like collection of elements
-// are indexed by a field does not exceed 1, and thus is assumed to be boolean
+// This can be useful in the case where an array-like collection of elements
+// are indexed by a field does not exceed 1, and thus is assumed to be boolean.
 func WithOberveIntEager(observeIntEager bool) GeneratorOption {
 	return func(g *Generator) {
 		g.oberveIntEager = observeIntEager

--- a/generator_test.go
+++ b/generator_test.go
@@ -318,6 +318,54 @@ func TestGenerator(t *testing.T) {
 				`}`,
 			),
 		},
+		{
+			name: "observe_int_eager",
+			options: []xmlstruct.GeneratorOption{
+				xmlstruct.WithOberveIntEager(true),
+			},
+			xmlStr: joinLines(
+				`<a>`,
+				`  <b index="0">one</b>`,
+				`  <b index="1">two</b>`,
+				`</a>`,
+			),
+			expectedStr: joinLines(
+				xmlstruct.DefaultHeader,
+				``,
+				`package main`,
+				``,
+				`type A struct {`,
+				"\tB []struct {",
+				"\t\tIndex    int    `xml:\"index,attr\"`",
+				"\t\tCharData string `xml:\",chardata\"`",
+				"\t} `xml:\"b\"`",
+				`}`,
+			),
+		},
+		{
+			name: "observe_int_eager_false",
+			options: []xmlstruct.GeneratorOption{
+				xmlstruct.WithOberveIntEager(false),
+			},
+			xmlStr: joinLines(
+				`<a>`,
+				`  <b index="0">one</b>`,
+				`  <b index="1">two</b>`,
+				`</a>`,
+			),
+			expectedStr: joinLines(
+				xmlstruct.DefaultHeader,
+				``,
+				`package main`,
+				``,
+				`type A struct {`,
+				"\tB []struct {",
+				"\t\tIndex    bool   `xml:\"index,attr\"`",
+				"\t\tCharData string `xml:\",chardata\"`",
+				"\t} `xml:\"b\"`",
+				`}`,
+			),
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/value.go
+++ b/value.go
@@ -68,6 +68,12 @@ func (v *value) goType(options *generateOptions) string {
 // observe records s as being observed for v.
 func (v *value) observe(s string, options *observeOptions) {
 	v.observations++
+	if options.observeIntEager {
+		if _, err := strconv.ParseInt(s, 10, 64); err == nil {
+			v.intCount++
+			return
+		}
+	}
 	if _, err := strconv.ParseBool(s); err == nil {
 		v.boolCount++
 		return

--- a/xmlstruct.go
+++ b/xmlstruct.go
@@ -24,6 +24,7 @@ const (
 	DefaultTimeLayout                   = "2006-01-02T15:04:05Z"
 	DefaultUsePointersForOptionalFields = true
 	DefaultUseRawToken                  = false
+	DefaultObserveIntEager              = false
 )
 
 var (
@@ -87,6 +88,7 @@ type observeOptions struct {
 	topLevelAttributes bool
 	topLevelElements   map[xml.Name]*element
 	useRawToken        bool
+	observeIntEager    bool
 }
 
 // generateOptions contains options for generating Go source.


### PR DESCRIPTION
Hello,

I ran into a scenario where an array-like collection of xml elements indexed by an attribute were being parsed as a boolean when the size of the was not greater than 2. Evidently, it is ambiguous whether something whose only instances are 0 and 1 should be cast as a boolean or not.

e.g.
```xml
<parent>
  <child ArrayIndex="0">
    chardata
  </child>
  <child ArrayIndex="1">
    chardata1
  </child>
</parent>
```
becomes `ArrayIndex bool`:
```go
type Parent struct {
    Child []struct {
        ArrayIndex bool   `xml:"ArrayIndex,attr"`
        CharData   string `xml:",chardata"`
    } `xml:"child"`
}
```
instead of `ArrayIndex int`:
```go
type Parent struct {
    Child []struct {
        ArrayIndex int      `xml:"ArrayIndex,attr"`
        CharData   string `xml:",chardata"`
    } `xml:"child"`
}
```

So I made a an "ObserveIntEager" flag in order to disambiguate this scenario. It essentially disallows "1" or "0" from ever being treated as a boolean at all by observing "int" first when it is enabled. 

`goxmlstruct -observe-int-eager <example>.xml`

---
Though, in the process of testing regression, i think i may have discovered some unintended behaviour. It seems that if there is a single instance of 1 or 0 in a collection of integers, the spec becomes "string". The reason being that 1 and 0 are always observed as "bool" (because it is observed first), and the combination of instances of "int" + "bool" is then treated as "string".

[Here are some test cases demonstrating the bug](https://github.com/twpayne/go-xmlstruct/compare/master...LiamWalsh98:go-xmlstruct:bool_parse_bug)

*Note that tests that include 1 or 0 fail, and the tests that do not include 1 or 0 pass.*

If we have a collection of integer values that include 1 or 0 (e.g. [`test_int_parse`](https://github.com/twpayne/go-xmlstruct/compare/master...LiamWalsh98:go-xmlstruct:bool_parse_bug#diff-2b8c027cd72512572ab33bed37a0c5da2ae61adb677e59f3818f18506d04e26eR322)), the spec becomes string. 

If none of the integer values are 1 or 0 (e.g. [`test_int_parse_without_1_0`](https://github.com/twpayne/go-xmlstruct/compare/master...LiamWalsh98:go-xmlstruct:bool_parse_bug#diff-2b8c027cd72512572ab33bed37a0c5da2ae61adb677e59f3818f18506d04e26eR345)), the spec correctly becomes int.

Now I am wondering whether 1 and 0 should just be excluded from the ParseBoolean check altogether. If that's the case then this PR should be closed.

P.S. Huge fan of chezmoi!
