### PR TITLE
Add config option to generate `string` type for empty xml elements rather than `struct{}`  Related to #4

### DIFF
--- a/cmd/goxmlstruct/main.go
+++ b/cmd/goxmlstruct/main.go
@@ -23,6 +23,7 @@ var (
 	topLevelAttributes           = flag.Bool("top-level-attributes", xmlstruct.DefaultTopLevelAttributes, "include top level attributes")
 	usePointersForOptionalFields = flag.Bool("use-pointers-for-optional-fields", xmlstruct.DefaultUsePointersForOptionalFields, "use pointers for optional fields")
 	useRawToken                  = flag.Bool("use-raw-token", xmlstruct.DefaultUseRawToken, "use encoding/xml.Decoder.RawToken")
+	noEmptyElements              = flag.Bool("no-empty-elements", !xmlstruct.DefaultEmptyElements, "use type string instead of struct{} for empty elements")
 )
 
 func run() error {
@@ -46,6 +47,7 @@ func run() error {
 		xmlstruct.WithTopLevelAttributes(*topLevelAttributes),
 		xmlstruct.WithUsePointersForOptionalFields(*usePointersForOptionalFields),
 		xmlstruct.WithUseRawToken(*useRawToken),
+		xmlstruct.WithEmptyElements(!*noEmptyElements),
 	)
 
 	if flag.NArg() == 0 {

--- a/generator.go
+++ b/generator.go
@@ -44,6 +44,7 @@ type Generator struct {
 	usePointersForOptionalFields bool
 	useRawToken                  bool
 	typeElements                 map[xml.Name]*element
+	emptyElements                bool
 }
 
 // A GeneratorOption sets an option on a Generator.
@@ -164,6 +165,14 @@ func WithUseRawToken(useRawToken bool) GeneratorOption {
 	}
 }
 
+// WithEmptyElements sets whether to use type struct{} or string
+// for empty xml elements.
+func WithEmptyElements(emptyElements bool) GeneratorOption {
+	return func(g *Generator) {
+		g.emptyElements = emptyElements
+	}
+}
+
 // NewGenerator returns a new Generator with the given options.
 func NewGenerator(options ...GeneratorOption) *Generator {
 	g := &Generator{
@@ -183,6 +192,7 @@ func NewGenerator(options ...GeneratorOption) *Generator {
 		usePointersForOptionalFields: DefaultUsePointersForOptionalFields,
 		useRawToken:                  DefaultUseRawToken,
 		typeElements:                 make(map[xml.Name]*element),
+		emptyElements:                DefaultEmptyElements,
 	}
 	g.exportNameFunc = func(name xml.Name) string {
 		if exportRename, ok := g.exportRenames[name.Local]; ok {
@@ -209,6 +219,7 @@ func (g *Generator) Generate() ([]byte, error) {
 		intType:                      g.intType,
 		preserveOrder:                g.preserveOrder,
 		usePointersForOptionalFields: g.usePointersForOptionalFields,
+		emptyElements:                g.emptyElements,
 	}
 
 	var typeElements []*element

--- a/generator_test.go
+++ b/generator_test.go
@@ -296,6 +296,20 @@ func TestGenerator(t *testing.T) {
 			),
 		},
 		{
+			name: "without_empty_elements",
+			options: []xmlstruct.GeneratorOption{
+				xmlstruct.WithEmptyElements(false),
+			},
+			xmlStr: `<a b="0"/>`,
+			expectedStr: joinLines(
+				xmlstruct.DefaultHeader,
+				``,
+				`package main`,
+				``,
+				`type A string`,
+			),
+		},
+		{
 			name: "char_data_field_name",
 			options: []xmlstruct.GeneratorOption{
 				xmlstruct.WithCharDataFieldName("Text"),

--- a/value.go
+++ b/value.go
@@ -48,7 +48,10 @@ func (v *value) goType(options *generateOptions) string {
 	}
 	switch {
 	case distinctTypes == 0:
-		return "struct{}"
+		if options.emptyElements {
+			return "struct{}"
+		}
+		return prefix + "string"
 	case distinctTypes == 1 && v.boolCount > 0:
 		return prefix + "bool"
 	case distinctTypes == 1 && v.intCount > 0:

--- a/xmlstruct.go
+++ b/xmlstruct.go
@@ -26,6 +26,7 @@ const (
 	DefaultTimeLayout                   = "2006-01-02T15:04:05Z"
 	DefaultUsePointersForOptionalFields = true
 	DefaultUseRawToken                  = false
+	DefaultEmptyElements                = true
 )
 
 var (
@@ -104,6 +105,7 @@ type generateOptions struct {
 	preserveOrder                bool
 	simpleTypes                  map[xml.Name]struct{}
 	usePointersForOptionalFields bool
+	emptyElements                bool
 }
 
 // sortedKeys returns the keys of m in order.


### PR DESCRIPTION
Related to #4