### PR TITLE
fix: gracefully handle empty package name with invalid xml input

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -351,7 +351,12 @@ func (g *Generator) Generate() ([]byte, error) {
 		}
 		sourceWithoutPackageDeclaration := make([]byte, 0, len(source))
 		sourceWithoutPackageDeclaration = append(sourceWithoutPackageDeclaration, source[:indexOfPackageDeclaration]...)
-		sourceWithoutPackageDeclaration = append(sourceWithoutPackageDeclaration, source[indexOfPackageDeclaration+len(packageDeclaration)+1:]...)
+		indexOfTypeDecleration := indexOfPackageDeclaration + len(packageDeclaration)
+		// remove \n prefix
+		if len(source) > indexOfTypeDecleration {
+			indexOfTypeDecleration++
+		}
+		sourceWithoutPackageDeclaration = append(sourceWithoutPackageDeclaration, source[indexOfTypeDecleration:]...)
 		source = sourceWithoutPackageDeclaration
 	}
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -260,6 +260,17 @@ func TestGenerator(t *testing.T) {
 			),
 		},
 		{
+			name: "no_package_empty_input",
+			options: []xmlstruct.GeneratorOption{
+				xmlstruct.WithHeader(""),
+				xmlstruct.WithNamedTypes(true),
+				xmlstruct.WithPackageName(""),
+				xmlstruct.WithFormatSource(true),
+			},
+			xmlStr:      "",
+			expectedStr: "",
+		},
+		{
 			name: "no_package_unformatted",
 			options: []xmlstruct.GeneratorOption{
 				xmlstruct.WithNamedTypes(true),


### PR DESCRIPTION
Fixes #33